### PR TITLE
Fix: Load player sprite in PlayerComponent

### DIFF
--- a/endless_runner/lib/endless_runner_game.dart
+++ b/endless_runner/lib/endless_runner_game.dart
@@ -1,5 +1,6 @@
 import 'package:flame/components.dart';
 import 'package:flame/game.dart';
+import 'package:flame/flame.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
 import 'dart:math';
@@ -53,6 +54,8 @@ class PlayerComponent extends SpriteComponent {
 
   @override
   Future<void> onLoad() async {
+    super.onLoad(); // It's good practice to call super.onLoad()
+    sprite = await Flame.images.load('player.png');
     moveToLane(1);
     position.y = 400;
   }

--- a/endless_runner/pubspec.yaml
+++ b/endless_runner/pubspec.yaml
@@ -61,7 +61,8 @@ flutter:
   uses-material-design: true
 
   # To add assets to your application, add an assets section, like this:
-  # assets:
+  assets:
+    - assets/images/
   #   - images/a_dot_burr.jpeg
   #   - images/a_dot_ham.jpeg
 

--- a/endless_runner/test/player_component_test.dart
+++ b/endless_runner/test/player_component_test.dart
@@ -1,0 +1,38 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flame/game.dart';
+import 'package:flame/flame.dart';
+import 'package:endless_runner/endless_runner_game.dart'; // Adjust with your actual game file path
+
+void main() {
+  // Ensure that Flutter bindings are initialized for Flame testing
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('PlayerComponent', () {
+    testWithGame<EndlessRunnerGame>(
+      'should load sprite on onLoad',
+      () async {
+        // Pre-clear cache if modifying Flame.images globally for tests
+        Flame.images.clearCache();
+        
+        // Create and mount the component
+        final playerComponent = PlayerComponent();
+        
+        // The game instance is provided by testWithGame
+        // Adding the component to a game and waiting for it to be mounted
+        // will trigger onLoad.
+        await game.ensureAdd(playerComponent);
+        
+        // Assert that the sprite is loaded
+        expect(playerComponent.sprite, isNotNull);
+        
+        // Optional: verify sprite dimensions or other properties if known
+        // expect(playerComponent.sprite?.originalSize, Vector2(expectedWidth, expectedHeight));
+
+        // Clean up cache after test if necessary, though testWithGame might handle some of this
+        Flame.images.clearCache();
+      },
+      // You can provide a custom game instance if needed, otherwise a default EndlessRunnerGame is created.
+      // createGame: () => EndlessRunnerGame(), 
+    );
+  });
+}


### PR DESCRIPTION
The player sprite was not being loaded, causing a `sprite != null` assertion error. This commit fixes the issue by:

- Loading the sprite in `PlayerComponent.onLoad()`.
- Updating `pubspec.yaml` to include the assets directory.
- Adding a way to verify that the player sprite is loaded correctly.